### PR TITLE
Fixes for SPS (non-instanced) rendering

### DIFF
--- a/BakedVolumetrics/Assets/BakedVolumetrics/Shaders/Scene/SceneVolumetricFog.shader
+++ b/BakedVolumetrics/Assets/BakedVolumetrics/Shaders/Scene/SceneVolumetricFog.shader
@@ -120,7 +120,7 @@
                 UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
 
                 //get our screen uv coords
-                fixed2 screenUV = UNITY_PROJ_COORD(i.screenPos);
+                fixed2 screenUV = i.screenPos.xy / i.screenPos.w;
 
 
 #if UNITY_UV_STARTS_AT_TOP

--- a/BakedVolumetrics/Assets/BakedVolumetrics/Shaders/Scene/SceneVolumetricFog.shader
+++ b/BakedVolumetrics/Assets/BakedVolumetrics/Shaders/Scene/SceneVolumetricFog.shader
@@ -120,7 +120,7 @@
                 UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
 
                 //get our screen uv coords
-                fixed2 screenUV = i.screenPos.xy / i.screenPos.w;
+                fixed2 screenUV = UNITY_PROJ_COORD(i.screenPos);
 
 
 #if UNITY_UV_STARTS_AT_TOP
@@ -136,7 +136,7 @@
 #endif
 
                 //draw our scene depth texture and linearize it
-                fixed linearDepth = LinearEyeDepth(SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, screenUV));
+                fixed linearDepth = LinearEyeDepth(SAMPLE_DEPTH_TEXTURE_PROJ(_CameraDepthTexture, UNITY_PROJ_COORD(i.screenPos)));
 
                 //calculate the world position view plane for the camera
                 fixed3 cameraWorldPositionViewPlane = i.camRelativeWorldPos.xyz / dot(i.camRelativeWorldPos.xyz, unity_WorldToCamera._m20_m21_m22);


### PR DESCRIPTION
Hey! Thank you for making this, I was able to downgrade the project to unity 2019 and get it working within 2019.4.31f1 (and within VRC itself).

But I found a bug (with a help of a friend who tested for me), where it wouldn't render in VR, only in desktop. VRChat currently uses SPS (non-instanced) rendering for its VR view and that mode had incorrect depth sampling. For some reason it requires using `SAMPLE_DEPTH_TEXTURE_PROJ` instead of just `SAMPLE_DEPTH_TEXTURE`, so I adjusted code to do that and it fixes the issue.

Here's how the depth issues looked

https://user-images.githubusercontent.com/3798928/194698581-1722c5ad-9b1c-40f7-a3a4-20c2c0d1a52e.mp4

You can see how the depth values were only visible at the edges in these weird triangle bits. Not sure what unity macros are doing there, but using the _PROJ variant made it work in both SPS and SPS-I!

Also, just wanted to add an extra note here, you can make unity enable depth pass without using AO (in case of VRC where you do not have access to adjusting Main Cam properties). All you need is a directional light with shadows enabled hitting some random empty layer - and unity will enable the depth pass for you. E.g. 
![image](https://user-images.githubusercontent.com/3798928/194698545-434ff044-05d0-45a6-ad14-33aab5dccfa5.png)
